### PR TITLE
Add const, fix style

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -4,6 +4,8 @@ namespace Ohanzee\Helper;
 
 class Cookie
 {
+    // Separate the salt and the value
+    const SALT_SEPARATOR = '~';
 
     /**
      * @var  string  Magic salt to add to the cookie
@@ -60,9 +62,9 @@ class Cookie
         // Find the position of the split between salt and contents
         $split = strlen(static::salt($key, null));
 
-        if (isset($cookie[$split]) && $cookie[$split] === '~') {
+        if (isset($cookie[$split]) && $cookie[$split] == static::SALT_SEPARATOR) {
             // Separate the salt and the value
-            list ($hash, $value) = explode('~', $cookie, 2);
+            list ($hash, $value) = explode(static::SALT_SEPARATOR, $cookie, 2);
 
             if (static::salt($key, $value) === $hash) {
                 // Cookie signature is valid
@@ -102,7 +104,7 @@ class Cookie
         }
 
         // Add the salt to the cookie value
-        $value = static::salt($name, $value).'~'.$value;
+        $value = static::salt($name, $value) . static::SALT_SEPARATOR. $value;
 
         return setcookie($name, $value, $expiration, static::$path, static::$domain, static::$secure, static::$httponly);
     }
@@ -137,15 +139,15 @@ class Cookie
     {
         // Require a valid salt
         if (!static::$salt) {
-            throw new InvalidArgumentException(
+            throw new UnexpectedValueException(
                 'A valid cookie salt is required. Please set Cookie::$salt before calling this method.' .
-                'For more information check the documentation'
+                'For more information check the documentation.'
             );
         }
 
         // Determine the user agent
         $agent = isset($_SERVER['HTTP_USER_AGENT']) ? strtolower($_SERVER['HTTP_USER_AGENT']) : 'unknown';
 
-        return sha1($agent.$name.$value.static::$salt);
+        return sha1($agent . $name . $value . static::$salt);
     }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -4,6 +4,9 @@ namespace Ohanzee\Helper;
 
 class File
 {
+    // 8k blocks of file
+    const BLOCK_SIZE = 8192;
+
     /**
      * Split a file into pieces matching a specific size. Used when you need to
      * split large files into smaller pieces for easy transmission.
@@ -22,9 +25,6 @@ class File
         // Change the piece size to bytes
         $piece_size = floor($piece_size * 1024 * 1024);
 
-        // Write files in 8k blocks
-        $block_size = 1024 * 8;
-
         // Total number of pieces
         $pieces = 0;
 
@@ -34,17 +34,17 @@ class File
 
             // Create a new file piece
             $piece = str_pad($pieces, 3, '0', STR_PAD_LEFT);
-            $piece = fopen($filename.'.'.$piece, 'wb+');
+            $piece = fopen($filename . '.' . $piece, 'wb+');
 
             // Number of bytes read
             $read = 0;
 
             do {
                 // Transfer the data in blocks
-                fwrite($piece, fread($file, $block_size));
+                fwrite($piece, fread($file, static::BLOCK_SIZE));
 
                 // Another block has been read
-                $read += $block_size;
+                $read += static::BLOCK_SIZE;
             } while ($read < $piece_size);
 
             // Close the piece
@@ -70,13 +70,10 @@ class File
         // Open the file
         $file = fopen($filename, 'wb+');
 
-        // Read files in 8k blocks
-        $block_size = 1024 * 8;
-
         // Total number of pieces
         $pieces = 0;
 
-        while (is_file($piece = $filename.'.'.str_pad($pieces + 1, 3, '0', STR_PAD_LEFT))) {
+        while (is_file($piece = $filename . '.' . str_pad($pieces + 1, 3, '0', STR_PAD_LEFT))) {
             // Read another piece
             $pieces += 1;
 
@@ -85,7 +82,7 @@ class File
 
             while (!feof($piece)) {
                 // Transfer the data in blocks
-                fwrite($file, fread($piece, $block_size));
+                fwrite($file, fread($piece, static::BLOCK_SIZE));
             }
 
             // Close the piece


### PR DESCRIPTION
Add constants for the values used in several methods.
Fix style (PSR-2) of multilines.
Replace exception: Cookie::$salt is not argument of Cookie::salt().
