### PR TITLE
Array to and from Mapping conversion

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -527,14 +527,14 @@ class Arr
      *
      * @return array
      */
-    public static function fromCollection(array $collection, $recursive = false, $key = 'name', $value = 'value')
+    public static function fromMapping(array $collection, $recursive = false, $key = 'name', $value = 'value')
     {
         foreach ($collection as $index => $obj) {
             if (!is_array($obj) || !isset($obj[$key]) || !isset($obj[$value])) {
                 unset($collection[$index]);
             }
             if ($recursive && is_array($obj[$value]) && !static::isAssoc($obj[$value])) {
-                $collection[$index][$value] = static::fromCollection($obj[$value], $recursive, $key, $value);
+                $collection[$index][$value] = static::fromMapping($obj[$value], $recursive, $key, $value);
             }
         }
 
@@ -542,8 +542,8 @@ class Arr
             return array_combine(array_column($collection, $key), array_column($collection, $value));
         } else {
             return array_combine(
-                static::path($collection, array('*', $key)),
-                static::path($collection, array('*', $value))
+                static::path($collection, ['*', $key]),
+                static::path($collection, ['*', $value])
             );
         }
     }
@@ -566,14 +566,14 @@ class Arr
      *
      * @return array
      */
-    public static function toCollection(array $array, $recursive = false, $key = 'name', $value = 'value')
+    public static function toMapping(array $array, $recursive = false, $key = 'name', $value = 'value')
     {
         foreach ($array as $index => $obj) {
-            $array[$index] = array(
+            $array[$index] = [
                 $key   => $index,
                 $value => is_array($obj) && static::isAssoc($obj) && $recursive
-                    ? static::toCollection($obj, $recursive) : $obj,
-            );
+                    ? static::toMapping($obj, $recursive) : $obj,
+            ];
         }
 
         return array_values($array);

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -542,8 +542,8 @@ class Arr
             return array_combine(array_column($collection, $key), array_column($collection, $value));
         } else {
             return array_combine(
-                static::path($collection, ['*', $key]),
-                static::path($collection, ['*', $value])
+                static::path($collection, array('*', $key)),
+                static::path($collection, array('*', $value))
             );
         }
     }
@@ -569,11 +569,11 @@ class Arr
     public static function toMapping(array $array, $recursive = false, $key = 'name', $value = 'value')
     {
         foreach ($array as $index => $obj) {
-            $array[$index] = [
+            $array[$index] = array(
                 $key   => $index,
                 $value => is_array($obj) && static::isAssoc($obj) && $recursive
                     ? static::toMapping($obj, $recursive) : $obj,
-            ];
+            );
         }
 
         return array_values($array);

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -510,7 +510,7 @@ class Arr
     }
 
     /**
-     * Convert a two-dimesion keyed array with key/value structure into an associated array.
+     * Convert a two-dimension keyed array with key/value structure into an associated array.
      *
      *     $array = array(array('field' => 'fname', 'value' => 'John'), array('field' => 'lname', 'value' => 'Doe'));
      *
@@ -541,12 +541,15 @@ class Arr
         if (function_exists('array_column')) {
             return array_combine(array_column($collection, $key), array_column($collection, $value));
         } else {
-            return array_combine(static::path($collection, array('*', $key)), static::path($collection, array('*', $value)));
+            return array_combine(
+                static::path($collection, array('*', $key)),
+                static::path($collection, array('*', $value))
+            );
         }
     }
 
     /**
-     * Convert a key/value array into two-dimenstion key/value structured array
+     * Convert a key/value array into two-dimension key/value structured array
      *
      *     $array = array('fname' => 'John', 'lname' => 'Doe');
      *


### PR DESCRIPTION
When building RESTful or RESTlike apps, I came across the request to allow passing bundles of information in the following format:
```json
[
  {
    "field": "fname",
    "value": "John"
  },
  {
    "field": "lname",
    "value": "Doe"
  }
]
```
For storing purposes, I needed it in the following format:
```php
<?php
array(
  'fname' => 'John',
  'lname' => 'Doe'
);
```

So utilizing the `Arr` class I added methods to convert back and forth between these two formats.